### PR TITLE
Add metals-emacs binary

### DIFF
--- a/apps/resources/metals-emacs.json
+++ b/apps/resources/metals-emacs.json
@@ -1,0 +1,12 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "properties": {
+    "metals.client": "emacs"
+  },
+  "javaOptions": ["-Xms100m", "-Xss4m"],
+  "dependencies": [
+    "org.scalameta::metals:latest.stable"
+  ]
+}


### PR DESCRIPTION
Other editors like vim, sublime and eclipse don't need a Metals binary
since we have custom plugins that handle the installation.