### PR TITLE
Add authors cli tool

### DIFF
--- a/apps-contrib/resources/authors.json
+++ b/apps-contrib/resources/authors.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    "central",
+    "bintray:jypma/maven"
+  ],
+  "dependencies": [
+    "lt.dvim.authors::authors-cli:latest.stable"
+  ]
+}


### PR DESCRIPTION
Really love the new coursier install command. I though I would add this little tool to the contrib channel so it can be easilly installed using coursier.

https://github.com/2m/authors