### PR TITLE
Create kafka-console-consumer.json

### DIFF
--- a/apps-contrib/resources/kafka-console-consumer.json
+++ b/apps-contrib/resources/kafka-console-consumer.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.apache.kafka::kafka:latest.stable"
-  ],
-  "name": "kafka-console-consumer"
+    "org.apache.kafka::kafka:latest.stable",
+    "org.slf4j:slf4j-nop:1.7.30"
+  ]
 }

--- a/apps-contrib/resources/kafka-console-consumer.json
+++ b/apps-contrib/resources/kafka-console-consumer.json
@@ -1,0 +1,10 @@
+{
+  "mainClass": "kafka.tools.ConsoleConsumer",
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.apache.kafka::kafka:latest.stable"
+  ],
+  "name": "kafka-console-consumer"
+}


### PR DESCRIPTION
Added support of `kafka-console-consumer`. It is a tool which allows one to connect to Kafka directly.

See more here:
https://kafka.apache.org/documentation/#quickstart_consume