### PR TITLE
Added BFG Repo-Cleaner

### DIFF
--- a/apps-contrib/resources/bfg.json
+++ b/apps-contrib/resources/bfg.json
@@ -4,5 +4,8 @@
   ],
   "dependencies": [
     "com.madgag:bfg:latest.stable"
+  ],
+  "exclusions": [
+    "org.slf4j:slf4j-simple"
   ]
 }

--- a/apps-contrib/resources/bfg.json
+++ b/apps-contrib/resources/bfg.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.madgag:bfg:latest.stable"
+  ]
+}


### PR DESCRIPTION
The following commit adds https://rtyley.github.io/bfg-repo-cleaner/ into coursier apps.

It shows the following message from time to time (not on every run), but I could not find a way to exclude it yet:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/ruslan/.cache/coursier/v1/https/repo1.maven.org/maven2/com/madgag/bfg/1.13.0/bfg-1.13.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/ruslan/.cache/coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.2/slf4j-simple-1.7.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
```