### PR TITLE
Add scalapbc to contrib

### DIFF
--- a/apps-contrib/resources/scalapbc.json
+++ b/apps-contrib/resources/scalapbc.json
@@ -1,8 +1,0 @@
-{
-  "repositories": [
-    "central"
-  ],
-  "dependencies": [
-    "com.thesamet.scalapb::scalapbc:latest.release"
-  ]
-}

--- a/apps-contrib/resources/scalapbc.json
+++ b/apps-contrib/resources/scalapbc.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.thesamet.scalapb::scalapbc:latest.release"
+  ]
+}

--- a/apps/resources/scalapbc.json
+++ b/apps/resources/scalapbc.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.thesamet.scalapb::scalapbc:latest.release"
+  ]
+}


### PR DESCRIPTION
scalapbc is a CLI tool for generating protocol buffers for ScalaPB.

See https://scalapb.github.io/scalapbc.html for more details.

I'll also be ok if this gets merged into the main channel but I am not sure what the guidelines are.