### PR TITLE
Enable -usejavacp by default for metac

### DIFF
--- a/apps/resources/metac.json
+++ b/apps/resources/metac.json
@@ -4,5 +4,8 @@
   ],
   "dependencies": [
     "org.scalameta:::metac:latest.stable"
-  ]
+  ],
+  "properties": {
+    "scala.usejavacp": "true"
+  }
 }


### PR DESCRIPTION
Without this change, `metac foo.scala` fails since the `-usejavacp` flag
needs to be explicitly passed in. I want to update the Scalameta website to recommend `cs install metac`, related https://github.com/scalameta/scalameta/issues/2023