### PR TITLE
Add ScalablyTyped CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out/
 target/
+.idea
+.metals

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ Feel free to send in a PR to add your application here!
  - jruby
  - jython
  - kafka-console-consumer
- - kafka-console-producer
- - kafka-consumer-groups
  - proguard-retrace
  - proguard
  - rhino

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Feel free to send in a PR to add your application here!
  - jruby
  - jython
  - kafka-console-consumer
+ - kafka-console-producer
+ - kafka-consumer-groups
  - proguard-retrace
  - proguard
  - rhino

--- a/apps/resources/stc.json
+++ b/apps/resources/stc.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    "bintray:oyvindberg/converter",
+    "central"
+  ],
+  "dependencies": [
+    "org.scalablytyped.converter:cli_2.12:latest.release"
+  ]
+}


### PR DESCRIPTION
I am adding this in apps (instead of apps-contrib) because I find the [stc](https://scalablytyped.org/docs/cli) cli similar to `scalabpc`. 

While `scalapbc` compiles `.proto` files, `stc` compiles `.d.ts` Typescript files.
