### PR TITLE
Update bloop.json

### DIFF
--- a/apps/resources/bloop.json
+++ b/apps/resources/bloop.json
@@ -2,6 +2,8 @@
   "repositories": [
     "central"
   ],
+  "launcherType": "graalvm-native-image",
+  "prebuilt": "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-${platform}",
   "dependencies": [
     "ch.epfl.scala::bloopgun:latest.stable"
   ]


### PR DESCRIPTION
@alexarchambault This change is so that people can install bloop 1.4.0 when it's out, I'm working on the release now.