### PR TITLE
Add bloop-jvm

### DIFF
--- a/apps/resources/bloop-jvm.json
+++ b/apps/resources/bloop-jvm.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "ch.epfl.scala::bloopgun:latest.stable"
+  ]
+}


### PR DESCRIPTION
Same as `bloop`, but without GraalVM stuff. Added as a fallback, in case anything goes wrong with the default `bloop` descriptor.