### PR TITLE
Add sbt-launch based launcher for sbt

### DIFF
--- a/apps/resources/csbt.json
+++ b/apps/resources/csbt.json
@@ -1,0 +1,17 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "io.get-coursier::sbt-launcher:latest.stable"
+  ],
+  "shared": [
+    "org.scala-sbt:launcher-interface"
+  ],
+  "properties": {
+    "jline.shutdownhook": "false",
+    "jna.nosys": "true",
+    "coursier.sbt-launcher.parse-args": "extras"
+  },
+  "javaOptions": ["-Xms512m", "-Xss2m"]
+}

--- a/apps/resources/sbt.json
+++ b/apps/resources/sbt.json
@@ -1,0 +1,14 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.scala-sbt:sbt-launch:latest.stable",
+    "io.get-coursier.sbt:sbt-runner:latest.stable"
+  ],
+  "properties": {
+    "jline.shutdownhook": "false",
+    "jna.nosys": "true"
+  },
+  "javaOptions": ["-Xms512m", "-Xss2m"]
+}


### PR DESCRIPTION
Based on [sbt-runner](https://github.com/coursier/sbt-runner), that parses arguments upfront like sbt-extras does (only supports arguments that can be handled once the JVM started).