### PR TITLE
Add `scala-steward` to the contrib channel

### DIFF
--- a/apps-contrib/resources/scala-steward.json
+++ b/apps-contrib/resources/scala-steward.json
@@ -1,0 +1,8 @@
+{
+    "repositories": [
+        "central"
+    ],
+    "dependencies": [
+        "org.scala-steward::scala-steward-core:latest.release"
+    ]
+}


### PR DESCRIPTION
This PR adds the possibility to use Coursier to launch [Scala Steward](https://github.com/fthomas/scala-steward).

## References

https://github.com/fthomas/scala-steward/issues/1453

