### PR TITLE
Default to latest.release rather than latest.stable for Ammonite

### DIFF
--- a/apps/resources/ammonite.json
+++ b/apps/resources/ammonite.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "com.lihaoyi:::ammonite:latest.stable"
+    "com.lihaoyi:::ammonite:latest.release"
   ],
   "classifiers": ["_", "sources"],
   "name": "amm"


### PR DESCRIPTION
Currently, there's no stable Ammonite release for scala 2.13.3, only
unstable ones. This currently confuses the coursier CLI, which finds
`com.lihaoyi:ammonite_2.13.3`, but not stable releases for it, which
makes installing Ammonite with `cs install ammonite` fail.

That's a limitation of the coursier CLI, and this needs to be addressed
in coursier. In the mean time, we default to latest.release here, so
that `cs install ammonite` works again.