### PR TITLE
Add scala-debugger in contrib channel

### DIFF
--- a/apps-contrib/resources/scala-debugger.json
+++ b/apps-contrib/resources/scala-debugger.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.scala-debugger::scala-debugger-tool:latest.release"
+  ]
+}


### PR DESCRIPTION
It's [not maintained anymore](https://github.com/ensime/scala-debugger) as of writing this, but adding the app here can be useful to toy with it nonetheless.