### PR TITLE
Add in a generic metals.

### DIFF
--- a/apps/resources/metals.json
+++ b/apps/resources/metals.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "javaOptions": ["-Xms100m", "-Xss4m"],
+  "dependencies": [
+    "org.scalameta::metals:latest.stable"
+  ]
+}


### PR DESCRIPTION
Metals now no longer needs to set the client property to be
properly configured. It can fully rely on the client using
initializtionOptions to correctly configure Metals for whichever
client the user may be using. This will allow for vim, emacs, etc
users to all just use the same metals instead of needing a
metals-emacs, metals-vim, etc. In the future we can just remove
the existing metals-emacs that is on here, but I wanted to get
this up here first and ensure that they can get switched over
before removing it.

You can read more about configuration no longer needing the client
setting here: https://scalameta.org/metals/blog/2020/07/23/configuring-a-client.html