### PR TITLE
Hardcode Scala 3 versions for now

### DIFF
--- a/apps/resources/scala3-compiler.json
+++ b/apps/resources/scala3-compiler.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3.0.0-M3:latest.release"
+    "org.scala-lang:scala3-compiler_3.0.0-M3:3.0.0-M3"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-decompiler.json
+++ b/apps/resources/scala3-decompiler.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3.0.0-M3:latest.release"
+    "org.scala-lang:scala3-compiler_3.0.0-M3:3.0.0-M3"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-doc.json
+++ b/apps/resources/scala3-doc.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-doc_3.0.0-M3:latest.release"
+    "org.scala-lang:scala3-doc_3.0.0-M3:3.0.0-M3"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-repl.json
+++ b/apps/resources/scala3-repl.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3.0.0-M3:latest.release"
+    "org.scala-lang:scala3-compiler_3.0.0-M3:3.0.0-M3"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
Without this, latest.release downloads nightlies, and latest.stable wouldn't find any suitable version, as it considers both milestones and nightlies to be unstable.