### PR TITLE
Move stc from bintray to maven central

### DIFF
--- a/apps/resources/stc.json
+++ b/apps/resources/stc.json
@@ -1,6 +1,6 @@
 {
   "repositories": [
-    "central",
+    "central"
   ],
   "dependencies": [
     "org.scalablytyped.converter::cli:latest.release"

--- a/apps/resources/stc.json
+++ b/apps/resources/stc.json
@@ -1,7 +1,6 @@
 {
   "repositories": [
     "central",
-    "bintray:oyvindberg/converter"
   ],
   "dependencies": [
     "org.scalablytyped.converter::cli:latest.release"


### PR DESCRIPTION
Hey there.

Since bintray is shutting down this might be one of many to make this leap. The Scalablytyped converter, stc for short, had to move to maven central.

Do you think this proposed change is enough for coursier to start resolving from maven central if it was already installed from bintray?

Before this PR both maven central and bintray were specified in the channel file. Probably because it was originally resolved in bintray, coursier doesn't descend into the directories in maven central.

(beta30 is on bintray, beta31 is on maven central)
```
[oyvind:~] 9m54s 1 $ whereis stc
stc: /home/olvind/.local/share/coursier/bin/stc
[oyvind:~] 10m21s 1 $ stc --version
ScalablyTyped Converter (version 1.0.0-beta30)
[oyvind:~] 10m31s 1 $ cs update
... snip
Downloading https://dl.bintray.com/oyvindberg/converter/org/scala-lang/scala-library/maven-metadata.xml
Downloaded https://dl.bintray.com/oyvindberg/converter/org/scala-lang/scala-library/maven-metadata.xml
Downloading https://dl.bintray.com/oyvindberg/converter/org/scala-lang/scala-library/maven-metadata.xml.sha1
Downloaded https://dl.bintray.com/oyvindberg/converter/org/scala-lang/scala-library/maven-metadata.xml.sha1
Checking https://repo1.maven.org/maven2/
Checked https://repo1.maven.org/maven2/
Checking https://repo1.maven.org/maven2/org/
Checked https://repo1.maven.org/maven2/org/
Checking https://repo1.maven.org/maven2/org/scalablytyped/
Checked https://repo1.maven.org/maven2/org/scalablytyped/
Checking https://repo1.maven.org/maven2/org/scalablytyped/converter/
Checked https://repo1.maven.org/maven2/org/scalablytyped/converter/
Checking https://dl.bintray.com/oyvindberg/converter/
Checked https://dl.bintray.com/oyvindberg/converter/
Downloading https://dl.bintray.com/oyvindberg/converter/
Downloaded https://dl.bintray.com/oyvindberg/converter/
Checking https://dl.bintray.com/oyvindberg/converter/org/
Checked https://dl.bintray.com/oyvindberg/converter/org/
Downloading https://dl.bintray.com/oyvindberg/converter/org/
Downloaded https://dl.bintray.com/oyvindberg/converter/org/
Checking https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/
Checked https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/
Downloading https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/
Downloaded https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/
Checking https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/
Checked https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/
Downloading https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/
Downloaded https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/
Checking https://repo1.maven.org/maven2/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checked https://repo1.maven.org/maven2/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checking https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checked https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checking https://repo1.maven.org/maven2/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checked https://repo1.maven.org/maven2/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checking https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
Checked https://dl.bintray.com/oyvindberg/converter/org/scalablytyped/converter/cli_2.12/maven-metadata.xml
[oyvind:~] 10m44s 1 $ stc --version
ScalablyTyped Converter (version 1.0.0-beta30)
```

I didn't know how to really test the update situation, but with `install` and this updated channel it works at least
```
cs install --default-channels=false  --channel ./apps/resources stc
...
Downloading https://repo1.maven.org/maven2/org/scalablytyped/converter/cli_2.12/1.0.0-beta31/cli_2.12-1.0.0-beta31.pom
```

