### PR TITLE
Add lsif-java to the contrib module

### DIFF
--- a/apps-contrib/resources/lsif-java.json
+++ b/apps-contrib/resources/lsif-java.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "mainClass": "com.sourcegraph.lsif_java.LsifJava",
+  "dependencies": [
+    "com.sourcegraph::lsif-java:latest.stable"
+  ]
+}

--- a/apps-contrib/resources/lsif-java.json
+++ b/apps-contrib/resources/lsif-java.json
@@ -2,7 +2,6 @@
   "repositories": [
     "central"
   ],
-  "mainClass": "com.sourcegraph.lsif_java.LsifJava",
   "dependencies": [
     "com.sourcegraph::lsif-java:latest.stable"
   ]


### PR DESCRIPTION
The lsif-java command-line tool can be used to generate LSIF indexes for
Java codebases. I tested the changes locally  and it seems to work as expected
```
❯ cs launch --default-channels=false --channel apps-contrib/resources/ lsif-java -- --help
https://repo1.maven.org/maven2/com/sourcegraph/lsif-java_2.13/0.2.0/lsif-java_2.13-0.2.0.pom
  100.0% [##########] 2.2 KiB (10.8 KiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/lsif-java_2.13/0.2.0/lsif-java_2.13-0.2.0.jar
  100.0% [##########] 5.5 MiB (4.4 MiB / s)
USAGE
  lsif-java COMMAND [OPTIONS]

COMMANDS
  help              Print this help message
  version           Print the version of this program
  index             Automatically generate an LSIF index in the current working directory.
  index-semanticdb  Converts SemanticDB files into a single LSIF index file.

  Use 'lsif-java help COMMAND' for more information on a specific command.

```