### PR TITLE
Fix the scala3-doc app

### DIFF
--- a/apps/resources/scala3-doc.json
+++ b/apps/resources/scala3-doc.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-doc_3:3.0.1"
+    "org.scala-lang:scaladoc_3:3.0.1"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
To avoid:

Resolution error: Error downloading org.scala-lang:scala3-doc_3:latest.stable
  not found: /Users/dnw/.ivy2/local/org.scala-lang/scala3-doc_3
  not found: https://repo1.maven.org/maven2/org/scala-lang/scala3-doc_3/maven-metadata.xml