### PR TITLE
Create scala3.json

### DIFF
--- a/apps/resources/scala3.json
+++ b/apps/resources/scala3.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:3.1.0-RC1"
+    "org.scala-lang:scala3-compiler_3:latest.release"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3.json
+++ b/apps/resources/scala3.json
@@ -1,0 +1,12 @@
+{
+  "mainClass": "dotty.tools.MainGenericRunner",
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.scala-lang:scala3-compiler_3:3.0.3-RC1-bin-20210815-1524a5a-NIGHTLY"
+  ],
+  "properties": {
+    "scala.usejavacp": "true"
+  }
+}

--- a/apps/resources/scala3.json
+++ b/apps/resources/scala3.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:3.0.3-RC1-bin-20210815-1524a5a-NIGHTLY"
+    "org.scala-lang:scala3-compiler_3:3.1.0-RC1"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
This adds scala3 runner to be installed from coursier by `cs install scala3`. The only problem is that `MainGenericRunner` will be introduced by `3.0.3` so for now we have to use snapshot version. Nonetheless, it's better than nothing.