### PR TITLE
Back to latest.stable for scala3-* apps

### DIFF
--- a/apps/resources/scala3-compiler.json
+++ b/apps/resources/scala3-compiler.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:3.0.2"
+    "org.scala-lang:scala3-compiler_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-decompiler.json
+++ b/apps/resources/scala3-decompiler.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:3.0.2"
+    "org.scala-lang:scala3-compiler_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-doc.json
+++ b/apps/resources/scala3-doc.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scaladoc_3:3.0.2"
+    "org.scala-lang:scaladoc_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scala3-repl.json
+++ b/apps/resources/scala3-repl.json
@@ -4,7 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:3.0.2"
+    "org.scala-lang:scala3-compiler_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
We had to specify the version manually pre-3.0.0, as the full version was used as a name suffix, and coursier didn't handle Scala 3 name suffixes fine. Now that the name suffix doesn't change, no need to hardcode the version.