### PR TITLE
feat: scala-cli via maven central

### DIFF
--- a/apps-contrib/resources/scala-cli.json
+++ b/apps-contrib/resources/scala-cli.json
@@ -1,0 +1,11 @@
+{
+  "repositories": [
+      "central",
+      "https://oss.sonatype.org/content/repositories/snapshots"
+  ],
+  "dependencies": [
+      "org.virtuslab.scala-cli::cli:latest.release"
+  ],
+  "launcherType": "graalvm-native-image",
+  "prebuilt": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-${platform}.gz"
+}

--- a/apps-contrib/resources/scala-cli.json
+++ b/apps-contrib/resources/scala-cli.json
@@ -1,11 +1,14 @@
 {
   "repositories": [
-      "central",
-      "https://oss.sonatype.org/content/repositories/snapshots"
+    "central"
   ],
   "dependencies": [
-      "org.virtuslab.scala-cli::cli:latest.release"
+    "org.virtuslab.scala-cli::cli:latest.release"
   ],
   "launcherType": "graalvm-native-image",
-  "prebuilt": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-${platform}.gz"
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
+    "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
+    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz"
+  }
 }


### PR DESCRIPTION
I think they have native images, but I did not investigate too much

```
david@FRANCOED1 ~/p/w/apps (master)> cs install --default-channels=false \
                                         --channel ./apps-contrib/resources/ \
                                         scala-cli
https://repo1.maven.org/maven2/org/scala-lang/scala-library/maven-metadata.xml
  No new update since 2021-09-14 19:43:09
https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-library/maven-metadata.xml
  No new update since 2020-03-29 09:13:13
https://repo1.maven.org/maven2/org/virtuslab/scala-cli/cli_2.12/maven-metadata.xml
  No new update since 2021-10-20 12:07:52
https://repo1.maven.org/maven2/org/virtuslab/scala-cli/cli_2.12/maven-metadata.xml
  No new update since 2021-10-20 12:07:52
https://oss.sonatype.org/content/repositories/snapshots/org/virtuslab/using_directives/0.0.5-a86b6cb-SNAPSHOT/maven-metadata.xml
  No new update since 2021-09-15 09:08:25
https://oss.sonatype.org/content/repositories/snapshots/org/virtuslab/using_directives/0.0.5-a86b6cb-SNAPSHOT/using_directives-0.0.5-a86b6cb-20210915.090823-1.pom
  No new update since 2021-09-15 09:08:26
https://repo1.maven.org/maven2/com/google/code/gson/gson/maven-metadata.xml
  No new update since 2021-08-20 16:14:16
https://oss.sonatype.org/content/repositories/snapshots/org/virtuslab/using_directives/0.0.5-a86b6cb-SNAPSHOT/using_directives-0.0.5-a86b6cb-20210915.090823-1.jar
  No new update since 2021-09-15 09:08:26
david@FRANCOED1 ~/p/w/apps (master)> scala-cli version
0.0.7
```