### PR TITLE
Fix coursier/coursier#1957: Always use the original sbt launcher.

### DIFF
--- a/apps/resources/sbt.json
+++ b/apps/resources/sbt.json
@@ -3,8 +3,15 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-sbt:sbt:latest.stable"
+    "org.scala-sbt:sbt-launch:latest.stable",
+    "io.get-coursier.sbt:sbt-runner:latest.stable"
   ],
+  "properties": {
+    "jline.shutdownhook": "false",
+    "jna.nosys": "true"
+  },
+  "javaOptions": ["-Xms512m", "-Xss2m"],
+  "jvmOptionFile": ".jvmopts",
   "launcherType": "prebuilt",
   "prebuilt": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbt"
 }

--- a/apps/resources/sbt.json
+++ b/apps/resources/sbt.json
@@ -3,13 +3,8 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-sbt:sbt-launch:latest.stable",
-    "io.get-coursier.sbt:sbt-runner:latest.stable"
+    "org.scala-sbt:sbt:latest.stable"
   ],
-  "properties": {
-    "jline.shutdownhook": "false",
-    "jna.nosys": "true"
-  },
-  "javaOptions": ["-Xms512m", "-Xss2m"],
-  "jvmOptionFile": ".jvmopts"
+  "launcherType": "prebuilt",
+  "prebuilt": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbt"
 }

--- a/apps/resources/sbtn.json
+++ b/apps/resources/sbtn.json
@@ -5,6 +5,6 @@
   "dependencies": [
     "org.scala-sbt:sbt:latest.stable"
   ],
-  "launcherType": "graalvm-native-image",
+  "launcherType": "prebuilt",
   "prebuilt": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-${platform}"
 }


### PR DESCRIPTION
This uses the new features merged in coursier:

* The ability to install from the contents of a .zip file
* The `prebuilt` launcher type

to ensure that we always install sbt and sbtn using their official distribution.