### PR TITLE
Update ammonite.json to point at new Main

### DIFF
--- a/apps/resources/ammonite.json
+++ b/apps/resources/ammonite.json
@@ -7,5 +7,11 @@
     "com.lihaoyi:::ammonite:latest.release"
   ],
   "classifiers": ["_", "sources"],
-  "name": "amm"
+  "name": "amm",
+  "versionOverrides": [
+    {
+      "versionRange": "(,2.4.1-5-3e8a87a4]",
+      "mainClass": "ammonite.Main?"
+    }
+  ]
 }

--- a/apps/resources/ammonite.json
+++ b/apps/resources/ammonite.json
@@ -1,5 +1,5 @@
 {
-  "mainClass": "ammonite.Main?",
+  "mainClass": "ammonite.AmmoniteMain?",
   "repositories": [
     "central"
   ],


### PR DESCRIPTION
In https://github.com/com-lihaoyi/Ammonite/pull/1229, the main method was renamed. Running the most recent version of ammonite via coursier gives:

```
Error: Main method not found in class ammonite.Main, please define the main method as:
   public static void main(String[] args)
or a JavaFX application class must extend javafx.application.Application
```

This can be worked around locally by running:
`cs launch ammonite -M ammonite.AmmoniteMain -- yourScript.sc`