### PR TITLE
feat: add in git-changelog to contrib

### DIFF
--- a/apps-contrib/resources/git-changelog.json
+++ b/apps-contrib/resources/git-changelog.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "se.bjurr.gitchangelog:git-changelog-command-line:latest.release"
+  ]
+}


### PR DESCRIPTION
This adds in the https://github.com/tomasbjerre/git-changelog-command-line.

Their own description is:

> This is a command line tool for generating a changelog, or releasenotes, from a GIT repository. It uses the Git Changelog Lib.