### PR TITLE
Back to graalvm-native-image launcher type for cs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: coursier/cache-action@v6.3
-      - uses: coursier/setup-action@v1.1.2
+      - uses: coursier/setup-action@v1.2.0-M1
         with:
           jvm: 8
           apps: sbt

--- a/apps/resources/cs.json
+++ b/apps/resources/cs.json
@@ -3,7 +3,7 @@
     "central",
     "typesafe:ivy-releases"
   ],
-  "launcherType": "prebuilt",
+  "launcherType": "graalvm-native-image",
   "dependencies": [
     "io.get-coursier::coursier-cli:latest.release"
   ],


### PR DESCRIPTION
That should fix issues with `prebuilt` launcher type that users have been seeing when updating `cs` from `2.0.x` to the newer `2.1.0` milestones.

That shouldn't change anything in practice for other users. As prebuilt launchers are available for most versions, `cs install` / `cs update` shouldn't attempt to build native images locally (and likely fail).