### PR TITLE
add version override for scala 3.0.0-3.0.2

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -11,6 +11,10 @@
   },
   "versionOverrides": [
     {
+      "versionRange": "[3.0.0,3.0.2]",
+      "mainClass": "dotty.tools.repl.Main"
+    },
+    {
       "versionRange": "(,2.max]",
       "mainClass": "scala.tools.nsc.MainGenericRunner",
       "dependencies": [


### PR DESCRIPTION
`dotty.tools.MainGenericRunner` was added in 3.1.0, so we need some other main class, I have chosen `dotty.tools.repl.Main` for now, but it's not ideal, as it will not run the main method of a supplied argument

the alternative solution would be to extract the bash script bundled with those versions, or publish a backport of `dotty.tools.MainGenericRunner` somewhere

fixes https://github.com/coursier/apps/issues/141