### PR TITLE
Add back scala-cli in contrib channel

### DIFF
--- a/apps-contrib/resources/scala-cli.json
+++ b/apps-contrib/resources/scala-cli.json
@@ -1,0 +1,14 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.virtuslab.scala-cli::cli:latest.release"
+  ],
+  "launcherType": "graalvm-native-image",
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
+    "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
+    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz"
+  }
+}


### PR DESCRIPTION
Alongside the main channel. That should allow users who installed it via the contrib channel to update to the latest version.