### PR TITLE
Add new "scip-java" app

### DIFF
--- a/apps-contrib/resources/scip-java.json
+++ b/apps-contrib/resources/scip-java.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.sourcegraph::scip-java:latest.stable"
+  ]
+}


### PR DESCRIPTION
The "lsif-java" project has been renamed into "scip-java". 