### PR TITLE
Mark lsif-java as deprecated

### DIFF
--- a/apps-contrib/resources/lsif-java.json
+++ b/apps-contrib/resources/lsif-java.json
@@ -1,4 +1,5 @@
 {
+  "deprecated": true,
   "repositories": [
     "central"
   ],


### PR DESCRIPTION
This app has been superseded by scip-java.