### PR TITLE
scala scripts: add dependencies to the scala3-staging and scala3-tasty-inspector libraries

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -4,7 +4,9 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:latest.stable"
+    "org.scala-lang:scala3-compiler_3:latest.stable",
+    "org.scala-lang:scala3-staging_3:latest.stable",
+    "org.scala-lang:scala3-tasty-inspector_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scalac.json
+++ b/apps/resources/scalac.json
@@ -4,7 +4,9 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:latest.stable"
+    "org.scala-lang:scala3-compiler_3:latest.stable",
+    "org.scala-lang:scala3-staging_3:latest.stable",
+    "org.scala-lang:scala3-tasty-inspector_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
this is meant to support the use case of using the scala script to run tasty inspector or quote staging.
see https://docs.scala-lang.org/scala3/reference/metaprogramming/staging.html#create-a-new-scala-3-project-with-staging-enabled