### PR TITLE
Specify a main class for scip-java app

### DIFF
--- a/apps-contrib/resources/lsif-java.json
+++ b/apps-contrib/resources/lsif-java.json
@@ -3,6 +3,7 @@
   "repositories": [
     "central"
   ],
+  "mainClass": "com.sourcegraph.scip_java.ScipJava",
   "dependencies": [
     "com.sourcegraph::lsif-java:latest.stable"
   ]


### PR DESCRIPTION
I'm not sure why this change is needed because the
`META-INF/MANIFEST.MF` file specifies "Main-Class:
com.sourcegraph.scip_java.ScipJava". I still get the following error
when trying to install the `scip-java` app.

```
❯ coursier install --contrib scip-java
https://repo1.maven.org/maven2/com/sourcegraph/scip-java_2.13/maven-metadata.xml
  No new update since 2022-05-31 13:00:10
No main class found
❯ coursier version
2.1.0-M6-26-gcec901e9a
```