### PR TITLE
from 3.1.3 scalac uses MainGenericCompiler

### DIFF
--- a/apps/resources/scalac.json
+++ b/apps/resources/scalac.json
@@ -1,5 +1,5 @@
 {
-  "mainClass": "dotty.tools.dotc.Main",
+  "mainClass": "dotty.tools.MainGenericCompiler",
   "repositories": [
     "central"
   ],
@@ -12,6 +12,10 @@
     "scala.usejavacp": "true"
   },
   "versionOverrides": [
+    {
+      "versionRange": "[3.0.0,3.1.2]",
+      "mainClass": "dotty.tools.dotc.Main"
+    },
     {
       "versionRange": "(,2.max]",
       "mainClass": "scala.tools.nsc.Main",


### PR DESCRIPTION
scala 3.1.3 released with the `dotty.tools.MainGenericCompiler` class, which ports majority of `scalac` bash script into a Scala main class.

Update `scalac` to use the new class from `3.1.3+`.