### PR TITLE
Revert "scala scripts: add dependencies to the scala3-staging and scala3-tasty-inspector libraries"

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -4,9 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:latest.stable",
-    "org.scala-lang:scala3-staging_3:latest.stable",
-    "org.scala-lang:scala3-tasty-inspector_3:latest.stable"
+    "org.scala-lang:scala3-compiler_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"

--- a/apps/resources/scalac.json
+++ b/apps/resources/scalac.json
@@ -4,9 +4,7 @@
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:latest.stable",
-    "org.scala-lang:scala3-staging_3:latest.stable",
-    "org.scala-lang:scala3-tasty-inspector_3:latest.stable"
+    "org.scala-lang:scala3-compiler_3:latest.stable"
   ],
   "properties": {
     "scala.usejavacp": "true"


### PR DESCRIPTION
The reverted PR prevents overriding the `scala` and `scalac` versions for scala 3, so as these library dependencies are not crucial, it would be good to revert this change.

Reverts coursier/apps#154