### PR TITLE
add in scala-update to contrib

### DIFF
--- a/apps-contrib/resources/scala-update.json
+++ b/apps-contrib/resources/scala-update.json
@@ -1,0 +1,13 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "io.github.kitlangton::scala-update:latest.release"
+  ],
+  "launcherType": "graalvm-native-image",
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "https://github.com/kitlangton/scala-update/releases/download/${version}/sup-linux-amd",
+    "x86_64-apple-darwin": "https://github.com/kitlangton/scala-update/releases/download/${version}/sup-macos-amd"
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/kitlangton/scala-update/issues/5.

@alexarchambault how does it work if all the platforms aren't listed? For example `scala-update` doesn't publish an image for windows, so does it just fall back to the JVM launcher if the user is on a platform that a prebuilt binary doesn't exist for?

cc @kitlangton