### PR TITLE
Remove amm-runner from contrib channel

### DIFF
--- a/apps-contrib/resources/amm-runner.json
+++ b/apps-contrib/resources/amm-runner.json
@@ -1,8 +1,0 @@
-{
-  "repositories": [
-    "central"
-  ],
-  "dependencies": [
-    "io.github.alexarchambault.ammonite::ammonite-runner-cli:latest.release"
-  ]
-}


### PR DESCRIPTION
See https://github.com/alexarchambault/ammonite-runner/pull/154 for context. Leaving this as a draft for now, for a lack of proper way to deprecate apps.