### PR TITLE
fix: be explicit about mdoc main

### DIFF
--- a/apps/resources/mdoc.json
+++ b/apps/resources/mdoc.json
@@ -2,6 +2,7 @@
   "repositories": [
     "central"
   ],
+  "mainClass": "mdoc.Main",
   "dependencies": [
     "org.scalameta::mdoc:latest.stable"
   ]


### PR DESCRIPTION
There was another main added to mdoc recently which means we need to be explicit about it here.