### PR TITLE
fix apple arm prebuilt binary url

### DIFF
--- a/apps/resources/cs.json
+++ b/apps/resources/cs.json
@@ -12,7 +12,7 @@
     "x86_64-pc-linux": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-linux.gz",
     "aarch64-pc-linux": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-aarch64-pc-linux.gz",
     "x86_64-apple-darwin": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-apple-darwin.gz",
-    "aarch64-apple-darwin": "https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-apple-darwin.gz",
+    "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-apple-darwin.gz",
     "x86_64-pc-win32": "zip+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-win32.zip"
   },
   "versionOverrides": [


### PR DESCRIPTION
Installing this app on apple arm computer end with binary that does not run:

```
/Users/daniilleontiev/Library/Application Support/Coursier/bin/cs: line 2: /Users/daniilleontiev/Library/Application Support/Coursier/bin/.cs.aux: cannot execute binary file /Users/daniilleontiev/Library/Application Support/Coursier/bin/cs: line 2: /Users/daniilleontiev/Library/Application Support/Coursier/bin/.cs.aux: Undefined error: 0
```

I've copied the application description above, fixed the url and run the command:

```bash
coursier install \
    --install-dir tmp-install \
    --default-channels=false \
    --channel $PWD \
    cs
```

It have created `tmp-install/cs` that runs sucessfully.

The PR should fix https://github.com/coursier/coursier/issues/2495