### PR TITLE
[scala-cli app]: add prebuilt binary for apple arm64

### DIFF
--- a/apps/resources/scala-cli.json
+++ b/apps/resources/scala-cli.json
@@ -9,7 +9,8 @@
   "prebuiltBinaries": {
     "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
     "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
-    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz"
+    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz",
+    "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-aarch64-apple-darwin.gz"
   },
   "versionOverrides": [
     {


### PR DESCRIPTION
It was tested like this:

```
$ cs install \
    --default-channels=false \
    --channel ./apps/resources \
    -v \
    --install-dir ~/Desktop/tmp \
    --cache ~/Desktop/tmp/cache \
    scala-cli
...
Wrote scala-cli
...
$ ~/Desktop/tmp/scala-cli --version
Scala CLI version: 0.1.15
Scala version (default): 3.2.0
```

It's workaround to fix https://github.com/coursier/coursier/issues/2537

The proper fix would be to update coursier to use graalvm 22.2 which has apple silicon support. But generating native image functionality is embedded in scala-cli as well - and it seems as duplicate functionality in coursier. The question is, should it be updated in coursier to use latest graal? (afaik, scala-cli has already moved to graal 22.2)