### PR TITLE
feature: Add scala-experimental to override default scala runner

### DIFF
--- a/apps/resources/scala-cli.json
+++ b/apps/resources/scala-cli.json
@@ -16,8 +16,7 @@
     {
       "versionRange": "[0.0.1,0.1.2]",
       "repositories": [
-        "central",
-        "sonatype:snapshots"
+        "central"
       ],
       "dependencies": [
         "org.virtuslab.scala-cli:cli_2.12:latest.release"

--- a/apps/resources/scala-experimental.json
+++ b/apps/resources/scala-experimental.json
@@ -17,8 +17,7 @@
     {
       "versionRange": "[0.0.1,0.1.2]",
       "repositories": [
-        "central",
-        "sonatype:snapshots"
+        "central"
       ],
       "dependencies": [
         "org.virtuslab.scala-cli:cli_2.12:latest.release"

--- a/apps/resources/scala-experimental.json
+++ b/apps/resources/scala-experimental.json
@@ -1,0 +1,34 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "org.virtuslab.scala-cli:cli_3:latest.release"
+  ],
+  "launcherType": "graalvm-native-image",
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
+    "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
+    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz",
+    "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-aarch64-apple-darwin.gz"
+  },
+  "name": "scala",
+  "versionOverrides": [
+    {
+      "versionRange": "[0.0.1,0.1.2]",
+      "repositories": [
+        "central",
+        "sonatype:snapshots"
+      ],
+      "dependencies": [
+        "org.virtuslab.scala-cli:cli_2.12:latest.release"
+      ]
+    },
+    {
+      "versionRange": "[0.1.3,0.1.4]",
+      "dependencies": [
+        "org.virtuslab.scala-cli:cli_2.13:latest.release"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This will enable users to try the experimental runner in two steps:
```
$ cs setup # installs the current default scala
$ cs install scala-experimental # replaces scala by Scala CLI
```