### PR TITLE
[scala-cli app]: add prebuilt binary for linux aarch64

### DIFF
--- a/apps/resources/scala-cli.json
+++ b/apps/resources/scala-cli.json
@@ -8,6 +8,7 @@
   "launcherType": "graalvm-native-image",
   "prebuiltBinaries": {
     "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
+    "aarch64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-aarch64-pc-linux.gz",
     "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
     "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz",
     "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-aarch64-apple-darwin.gz"


### PR DESCRIPTION
It tested like this:
```
./cs-aarch64-pc-linux install scala-cli  \
               --default-channels=false \
               --channel ./apps/resources  \
               --install-dir .
./scala-cli hello.sc
Starting compilation server
Downloading compilation server 1.5.4-sc-4
Compiling project (Scala 3.2.1, JVM)
Compiled project (Scala 3.2.1, JVM)
hello
$ ./scala-cli about
Scala CLI version: 0.1.19
Scala version (default): 3.2.1
```
