### PR TITLE
migrate scala.json to contents of scala-experimental.json

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -1,24 +1,32 @@
 {
-  "mainClass": "dotty.tools.MainGenericRunner",
   "repositories": [
     "central"
   ],
   "dependencies": [
-    "org.scala-lang:scala3-compiler_3:latest.stable"
+    "org.virtuslab.scala-cli:cli_3:latest.release"
   ],
-  "properties": {
-    "scala.usejavacp": "true"
+  "launcherType": "graalvm-native-image",
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-linux.gz",
+    "x86_64-pc-win32": "zip+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-pc-win32.zip",
+    "x86_64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-x86_64-apple-darwin.gz",
+    "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/scala-cli/releases/download/v${version}/scala-cli-aarch64-apple-darwin.gz"
   },
+  "name": "scala",
   "versionOverrides": [
     {
-      "versionRange": "[3.0.0,3.0.2]",
-      "mainClass": "dotty.tools.repl.Main"
+      "versionRange": "[0.0.1,0.1.2]",
+      "repositories": [
+        "central"
+      ],
+      "dependencies": [
+        "org.virtuslab.scala-cli:cli_2.12:latest.release"
+      ]
     },
     {
-      "versionRange": "(,2.max]",
-      "mainClass": "scala.tools.nsc.MainGenericRunner",
+      "versionRange": "[0.1.3,0.1.4]",
       "dependencies": [
-        "org.scala-lang:scala-compiler:latest.stable"
+        "org.virtuslab.scala-cli:cli_2.13:latest.release"
       ]
     }
   ]


### PR DESCRIPTION
fulfil [SIP #46](https://docs.scala-lang.org/sips/scala-cli.html) by updating the scala command installed by cs setup to be Scala CLI.

@alexarchambault is it ok to just replace the contents like this? or does there need to be some other version override to include the old way?

or should this be handled by `cs setup` installing a different app?