### PR TITLE
Add sn-vcpkg

### DIFF
--- a/apps-contrib/resources/sn-vcpkg.json
+++ b/apps-contrib/resources/sn-vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.indoorvivants.vcpkg:sn-vcpkg_3:latest.release"
+  ]
+}


### PR DESCRIPTION
```
> cs launch com.indoorvivants.vcpkg:sn-vcpkg_3:latest.release -- --help
Usage:
    sn-vcpkg install
    sn-vcpkg bootstrap
    sn-vcpkg clang
    sn-vcpkg clang++
    sn-vcpkg scala-cli

Bootstraps and installs vcpkg dependencies in a way compatible with
the build tool plugins for SBT or Mill

Options and flags:
    --help
        Display this help text.

Subcommands:
    install
        Install a list of vcpkg dependencies
    bootstrap
        Bootstrap vcpkg
    clang
        Invoke clang with the correct flags for passed dependenciesThe format of the command is [sn-vcpkg clang <flags> <dependencies> -- <clang arguments>
    clang++
        Invoke clang++ with the correct flags for passed dependencies.
        The format of the command is [sn-vcpkg clang++ <flags> <dependencies> -- <clang arguments>
    scala-cli
        Invoke Scala CLI with correct flags for passed dependencies. Sets --native automatically!The format of the command is [sn-vcpkg scala-cli <flags> <dependencies> -- <scala-cli arguments>
```