### PR TITLE
Add sn-bindgen: https://sn-bindgen.indoorvivants.com/

### DIFF
--- a/apps-contrib/resources/sn-bindgen.json
+++ b/apps-contrib/resources/sn-bindgen.json
@@ -1,0 +1,15 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "com.indoorvivants:bindgen_native0.4_3:latest.stable"
+  ],
+  "launcherType": "scala-native",
+  "prebuiltBinaries": {
+    "x86_64-pc-linux": "https://github.com/indoorvivants/sn-bindgen/releases/download/v${version}/sn-bindgen-x86_64-pc-linux",
+    "x86_64-pc-win32": "https://github.com/indoorvivants/sn-bindgen/releases/download/v${version}/sn-bindgen-x86_64-pc-win32.exe",
+    "x86_64-apple-darwin": "https://github.com/indoorvivants/sn-bindgen/releases/download/v${version}/sn-bindgen-x86_64-apple-darwin",
+    "aarch64-apple-darwin": "https://github.com/indoorvivants/sn-bindgen/releases/download/v${version}/sn-bindgen-aarch64-apple-darwin"
+  }
+}


### PR DESCRIPTION
I _think_ this is right.

Previously I've tested it by supplying my own channel: 

```
cs install sn-bindgen --channel https://cs.indoorvivants.com/i.json
```

It only has prebuilt binaries, and for these platforms they _should_ be available.