### PR TITLE
Add Späti

### DIFF
--- a/apps-contrib/resources/spaeti.json
+++ b/apps-contrib/resources/spaeti.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    "central"
+  ],
+  "dependencies": [
+    "eu.joaocosta:spaeti_3:latest.stable"
+  ],
+  "mainClass": "eu.joaocosta.spaeti.main"
+}


### PR DESCRIPTION
Add [Späti](https://github.com/JD557/spaeti) to the contributors repository.

Calling `cs launch --channel . spaeti` from `./apps-contrib/resources` works as expected (also tested the bootstrap and install commands as mentioned in the documentation).