### PR TITLE
Add scala version override for 3.5.0-RC1

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -11,6 +11,11 @@
   },
   "versionOverrides": [
     {
+      "versionRange": "[3.5.0-RC1,)",
+      "launcherType": "prebuilt",
+      "prebuilt": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}.zip!scala3-${version}/bin/scala"
+    },
+    {
       "versionRange": "[3.0.0,3.0.2]",
       "mainClass": "dotty.tools.repl.Main"
     },


### PR DESCRIPTION
This should wait until we confirm that 3.5.0-RC1 is uploaded to GitHub

part of https://github.com/scala/scala3/issues/20098

also depends on users upgrading coursier due to https://github.com/coursier/coursier/pull/2975