### PR TITLE
use native launchers for scala from 3.5.0-RC2

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -11,7 +11,18 @@
   },
   "versionOverrides": [
     {
-      "versionRange": "[3.5.0-RC1,)",
+      "versionRange": "[3.5.0-RC2,)",
+      "launcherType": "prebuilt",
+      "prebuiltBinaries": {
+        "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
+        "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
+        "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
+        "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
+        "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"
+      }
+    },
+    {
+      "versionRange": "[3.5.0-RC1,3.5.0-RC1]",
       "launcherType": "prebuilt",
       "prebuilt": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}.zip!scala3-${version}/bin/scala"
     },


### PR DESCRIPTION
for faster startup

fixes #230 