### PR TITLE
Fix smithy language server invocation

### DIFF
--- a/apps-contrib/resources/smithy-language-server.json
+++ b/apps-contrib/resources/smithy-language-server.json
@@ -2,6 +2,7 @@
   "repositories": [
     "central"
   ],
+  "mainClass": "software.amazon.smithy.lsp.Main",
   "dependencies": [
     "software.amazon.smithy:smithy-language-server:latest.release"
   ]


### PR DESCRIPTION
From version 0.2.4 onwards the default main class that is run is that of smithy
CLI presumably owing to how the jar is constructed, this instead ensures that we
invoke the language server.

See https://github.com/smithy-lang/smithy-language-server/issues/143
