### PR TITLE
metap has its own artifact now

### DIFF
--- a/apps/resources/metap-native.json
+++ b/apps/resources/metap-native.json
@@ -6,5 +6,13 @@
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
     "org.scalameta::semanticdb-metap::latest.stable"
+  ],
+  "versionOverrides": [
+    {
+      "versionRange": "(,4.9.7]",
+      "dependencies": [
+        "org.scalameta::scalameta::latest.stable"
+      ]
+    }
   ]
 }

--- a/apps/resources/metap-native.json
+++ b/apps/resources/metap-native.json
@@ -5,6 +5,6 @@
   "launcherType": "scala-native",
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
-    "org.scalameta::scalameta::latest.stable"
+    "org.scalameta::semanticdb-metap::latest.stable"
   ]
 }

--- a/apps/resources/metap.json
+++ b/apps/resources/metap.json
@@ -5,5 +5,13 @@
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
     "org.scalameta::semanticdb-metap:latest.stable"
+  ],
+  "versionOverrides": [
+    {
+      "versionRange": "(,4.9.7]",
+      "dependencies": [
+        "org.scalameta::scalameta::latest.stable"
+      ]
+    }
   ]
 }

--- a/apps/resources/metap.json
+++ b/apps/resources/metap.json
@@ -4,6 +4,6 @@
   ],
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
-    "org.scalameta::scalameta:latest.stable"
+    "org.scalameta::semanticdb-metap:latest.stable"
   ]
 }


### PR DESCRIPTION
Since scalameta 4.9.8, metap lives in [its own artifact](https://mvnrepository.com/artifact/org.scalameta/semanticdb-metap).

Follows
- https://github.com/scalameta/scalameta/pull/3747
- https://github.com/scalameta/scalameta/pull/3749