### PR TITLE
bugfix: Use newer Bloop as default

### DIFF
--- a/apps/resources/bloop-jvm.json
+++ b/apps/resources/bloop-jvm.json
@@ -3,12 +3,14 @@
     "central"
   ],
   "dependencies": [
-    "ch.epfl.scala::bloopgun-core:latest.stable"
+    "ch.epfl.scala::bloop-cli:latest.stable"
   ],
+  "mainClass": "bloop.cli.Bloop",
   "versionOverrides": [
     {
-      "versionRange": "[2.0.0,)",
-      "dependencies": ["ch.epfl.scala::bloop-cli:latest.stable"]
+      "versionRange": "[,1.max)",
+      "dependencies": ["ch.epfl.scala::bloopgun-core:latest.stable"],
+      "mainClass": "bloop.bloopgun.Bloopgun"
     }
   ]
 }

--- a/apps/resources/bloop.json
+++ b/apps/resources/bloop.json
@@ -2,13 +2,15 @@
   "repositories": ["central"],
   "launcherType": "graalvm-native-image",
   "prebuilt": "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-${platform}",
-  "dependencies": ["ch.epfl.scala::bloopgun-core:latest.stable"],
+  "dependencies": ["ch.epfl.scala::bloop-cli:latest.stable"],
+  "mainClass": "bloop.cli.Bloop",
   "versionOverrides": [
     {
-      "versionRange": "[2.0.0,)",
+      "versionRange": "[,1.max)",
       "launcherType": "graalvm-native-image",
       "prebuilt": "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-${platform}",
-      "dependencies": ["ch.epfl.scala::bloop-cli:latest.stable"]
+      "dependencies": ["ch.epfl.scala::bloopgun-core:latest.stable"],
+      "mainClass": "bloop.bloopgun.Bloopgun"
     }
   ]
 }


### PR DESCRIPTION
Seems similar issue to https://github.com/coursier/apps/pull/239/files

This also makes sure we fallback to correct bloop JVM