### PR TITLE
semanticdb-metap is published with full version

### DIFF
--- a/apps/resources/metap-native.json
+++ b/apps/resources/metap-native.json
@@ -5,7 +5,7 @@
   "launcherType": "scala-native",
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
-    "org.scalameta::semanticdb-metap::latest.stable"
+    "org.scalameta:::semanticdb-metap::latest.stable"
   ],
   "versionOverrides": [
     {

--- a/apps/resources/metap.json
+++ b/apps/resources/metap.json
@@ -4,7 +4,7 @@
   ],
   "mainClass": "scala.meta.cli.Metap",
   "dependencies": [
-    "org.scalameta::semanticdb-metap:latest.stable"
+    "org.scalameta:::semanticdb-metap:latest.stable"
   ],
   "versionOverrides": [
     {


### PR DESCRIPTION
Follows https://github.com/coursier/apps/pull/240

Apologies @tgodzik, I hadn't figured out how to test it 🙈  I guess a [custom channel](https://get-coursier.io/docs/cli-install#channels) would do?