### PR TITLE
Corrected the architecture for aarch64-pc-linux prebuiltBinaries

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -11,7 +11,7 @@
   "launcherType": "prebuilt",
   "prebuiltBinaries": {
     "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
-    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
+    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-aarch64-pc-linux/bin/scala",
     "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
     "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
     "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"


### PR DESCRIPTION
Corrected the architecture part of the prebuiltBinaries aarch64-pc-linux from x86_64 to aarch64. This issue didn't allow the correct setup on an arm linux machine.
I tested the code against a Fedora 40 Workstation aarch64 architecture 