### PR TITLE
Update sbtn descriptor

### DIFF
--- a/apps/resources/sbtn.json
+++ b/apps/resources/sbtn.json
@@ -9,8 +9,20 @@
   "prebuiltBinaries": {
     "x86_64-pc-linux": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-pc-linux",
     "aarch64-pc-linux": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-aarch64-pc-linux",
-    "x86_64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-apple-darwin",
-    "aarch64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-aarch64-apple-darwin",
+    "x86_64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-universal-apple-darwin",
+    "aarch64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-universal-apple-darwin",
     "x86_64-pc-win32": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-pc-win32.exe"
-  }
+  },
+  "versionOverrides": [
+    {
+      "versionRange": "(,1.10.0)",
+      "prebuiltBinaries": {
+        "x86_64-pc-linux": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-pc-linux",
+        "aarch64-pc-linux": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-aarch64-pc-linux",
+        "x86_64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-apple-darwin",
+        "aarch64-apple-darwin": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-aarch64-apple-darwin",
+        "x86_64-pc-win32": "zip+https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.zip!sbt/bin/sbtn-x86_64-pc-win32.exe"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
So that it uses the new `sbt/bin/sbtn-universal-apple-darwin` launcher in the sbt archive

This is making `coursier/setup-action` fail in workflows running on macos, like [here](https://github.com/coursier/coursier/actions/runs/11552924146/job/32153004310#step:4:58):
```text
Install Apps
  /Users/runner/hostedtoolcache/cs/2.1.14/x64/cs install --contrib sbtn
  No main class found
Error: The process '/Users/runner/hostedtoolcache/cs/2.1.14/x64/cs' failed with exit code 1
```

And more generally, makes `cs install` fail to install `sbtn`.