### PR TITLE
Use cs Mac ARM binaries from mainline coursier repo

### DIFF
--- a/apps/resources/cs.json
+++ b/apps/resources/cs.json
@@ -12,10 +12,20 @@
     "x86_64-pc-linux": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-linux.gz",
     "aarch64-pc-linux": "gz+https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-pc-linux.gz",
     "x86_64-apple-darwin": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-apple-darwin.gz",
-    "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-apple-darwin.gz",
+    "aarch64-apple-darwin": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-aarch64-apple-darwin.gz",
     "x86_64-pc-win32": "zip+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-win32.zip"
   },
   "versionOverrides": [
+    {
+      "versionRange": "(2.1.0-RC4, 2.1.15]",
+      "prebuiltBinaries": {
+        "x86_64-pc-linux": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-linux.gz",
+        "aarch64-pc-linux": "gz+https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-pc-linux.gz",
+        "x86_64-apple-darwin": "gz+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-apple-darwin.gz",
+        "aarch64-apple-darwin": "gz+https://github.com/VirtusLab/coursier-m1/releases/download/v${version}/cs-aarch64-apple-darwin.gz",
+        "x86_64-pc-win32": "zip+https://github.com/coursier/coursier/releases/download/v${version}/cs-x86_64-pc-win32.zip"
+      }
+    },
     {
       "versionRange": "(2.0.16, 2.1.0-RC4]",
       "prebuiltBinaries": {


### PR DESCRIPTION
The main coursier repo new builds its own Mac ARM binaries since https://github.com/coursier/coursier/pull/3148, no need to use those from `VirtusLab/coursier-m1` for this anymore