### PR TITLE
Adapt Scala3 prebuiltBinaries paths inside archives to the fixed layout in 3.6.0+

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -10,13 +10,23 @@
   },
   "launcherType": "prebuilt",
   "prebuiltBinaries": {
-    "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
-    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-aarch64-pc-linux/bin/scala",
-    "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
-    "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
-    "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"
+    "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!bin/scala",
+    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!bin/scala",
+    "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!bin/scala",
+    "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!bin/scala",
+    "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!bin/scala"
   },
   "versionOverrides": [
+    {
+      "versionRange": "[3.5.0-RC2,3.5.2]",
+      "prebuiltBinaries": {
+        "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
+        "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-aarch64-pc-linux/bin/scala",
+        "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
+        "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
+        "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"
+      }
+    },
     {
       "versionRange": "[3.5.0-RC1,3.5.0-RC1]",
       "launcherType": "prebuilt",


### PR DESCRIPTION
In 3.5 series the  the paths inside the archives had incorrect layout that introduce 1 additional top-level directory. It was accidently fixed in 3.6 but coused incompatibility when installing native runnners. 

```sh
tar -tvf scala3-3.6.2-RC3-aarch64-apple-darwin.tar.gz
drwxr-xr-x  0 root   root        0 Nov 28 17:03 ./
-rwxr--r--  0 root   root     2613 Nov 28 16:56 ./bin/scalac
-rwxr--r--  0 root   root     2094 Nov 28 16:56 ./bin/scaladoc
-rw-r--r--  0 root   root     2818 Nov 28 16:56 ./bin/scaladoc.bat
-rwxr--r--  0 root   root     1640 Nov 28 16:56 ./bin/scala
-rwxr--r--  0 root   root     1883 Nov 28 16:56 ./bin/scala_legacy
-rw-r--r--  0 root   root     1789 Nov 28 16:56 ./bin/scala.bat
-rw-r--r--  0 root   root     3200 Nov 28 16:56 ./bin/scalac.bat
-rw-r--r--  0 root   root       73 Nov 28 17:03 ./VERSION
...
```

```sh
tar -tvf scala3-3.5.2-aarch64-apple-darwin.tar.gz 
-rwxr-xr-x  0 root   root     2609 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scalac
-rwxr-xr-x  0 root   root      975 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/common
-rwxr-xr-x  0 root   root     2090 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scaladoc
-rwxr-xr-x  0 root   root     1538 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/common.bat
-rwxr-xr-x  0 root   root     2814 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scaladoc.bat
-rwxr-xr-x  0 root   root     1632 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scala
-rwxr-xr-x  0 root   root     1879 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scala_legacy
-rwxr-xr-x  0 root   root     1781 Oct 16 12:20 scala3-3.5.2-aarch64-apple-darwin/bin/scala.bat
...
```