### PR TITLE
Revert "Adapt Scala3 prebuiltBinaries paths inside archives to the fixed layout in 3.6.0+"

### DIFF
--- a/apps/resources/scala.json
+++ b/apps/resources/scala.json
@@ -10,23 +10,13 @@
   },
   "launcherType": "prebuilt",
   "prebuiltBinaries": {
-    "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!bin/scala",
-    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!bin/scala",
-    "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!bin/scala",
-    "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!bin/scala",
-    "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!bin/scala"
+    "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
+    "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-aarch64-pc-linux/bin/scala",
+    "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
+    "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
+    "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"
   },
   "versionOverrides": [
-    {
-      "versionRange": "[3.5.0-RC2,3.5.2]",
-      "prebuiltBinaries": {
-        "x86_64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-linux.tar.gz!scala3-${version}-x86_64-pc-linux/bin/scala",
-        "aarch64-pc-linux": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-pc-linux.tar.gz!scala3-${version}-aarch64-pc-linux/bin/scala",
-        "x86_64-pc-win32": "zip+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-pc-win32.zip!scala3-${version}-x86_64-pc-win32/bin/scala",
-        "x86_64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-x86_64-apple-darwin.tar.gz!scala3-${version}-x86_64-apple-darwin/bin/scala",
-        "aarch64-apple-darwin": "gz+https://github.com/scala/scala3/releases/download/${version}/scala3-${version}-aarch64-apple-darwin.tar.gz!scala3-${version}-aarch64-apple-darwin/bin/scala"
-      }
-    },
     {
       "versionRange": "[3.5.0-RC1,3.5.0-RC1]",
       "launcherType": "prebuilt",


### PR DESCRIPTION
Reverts coursier/apps#256 

See https://github.com/scala/scala3/pull/22199 - we're going to republish Scala 3.6.2 GH release artifacts with the old layout