### PR TITLE
Update mainClass in Kafka Console Consumer

### DIFF
--- a/apps-contrib/resources/kafka-console-consumer.json
+++ b/apps-contrib/resources/kafka-console-consumer.json
@@ -1,5 +1,5 @@
 {
-  "mainClass": "kafka.tools.ConsoleConsumer",
+  "mainClass": "org.apache.kafka.tools.consumer.ConsoleConsumer",
   "repositories": [
     "central"
   ],


### PR DESCRIPTION
Kafka folks are refactoring their tools and has changed the package for ConsoleConsumer https://github.com/apache/kafka/blob/3.9.0/bin/kafka-console-consumer.sh#L21 
ConsoleProducer is unaffected in latest released version, so, for now updating only kafka-console-consumer